### PR TITLE
feature : ignore dirs related to test

### DIFF
--- a/packed.el
+++ b/packed.el
@@ -139,11 +139,14 @@ and the file name is displayed in the echo area."
 
 (defun packed-ignore-directory-p (directory)
   "Return t if DIRECTORY is being ignored when searching for libraries.
-DIRECTORY and all libraries it and its subdirectories contain
-are being ignored if it contains a file named \".nosearch\" or
-if it is a hidden directory."
+DIRECTORY and all libraries it and its subdirectories contain are being
+ignored if it contains a file named \".nosearch\" or if it's used for
+test or if it is a hidden directory."
   (or (string-prefix-p "." (file-name-nondirectory
                             (directory-file-name directory)))
+      (string-match-p "\\b\\(test\\|TEST\\)[sS]?\\b"
+                      (file-name-nondirectory
+                       (directory-file-name directory)))
       (file-exists-p (expand-file-name ".nosearch" directory))))
 
 (defmacro packed-with-file (file &rest body)


### PR DESCRIPTION
When I use `toggle-auto-compile` with a positive prefix argument, It compiles **/test/*.el at same time in some packages, so I ignore directories match regexp "test". 

As for files like **-test.el (avy-test.el,hydra-test.el etc.)  I have no idea right now.